### PR TITLE
Fix SplitText error

### DIFF
--- a/splittext/fadein-text.html
+++ b/splittext/fadein-text.html
@@ -19,9 +19,26 @@
 <body>  <div id="text">テキストアニメーション</div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/SplitText.min.js"></script>
   <script>
-    const split = new SplitText('#text', { type: 'chars' });
+    function simpleSplitText(selector) {
+      const element = document.querySelector(selector);
+      const original = element.textContent;
+      element.textContent = '';
+      const chars = original.split('').map(char => {
+        const span = document.createElement('span');
+        span.textContent = char;
+        element.appendChild(span);
+        return span;
+      });
+      return {
+        chars,
+        revert() {
+          element.textContent = original;
+        }
+      };
+    }
+
+    const split = simpleSplitText('#text');
     gsap.set(split.chars, { opacity: 0 });
     gsap.to(split.chars, {
       opacity: 1,


### PR DESCRIPTION
## Summary
- implement a custom `simpleSplitText` helper
- animate text characters using GSAP without the SplitText plugin

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ea37225e08323a6660579a70f2665